### PR TITLE
Add simple digest authentication middleware behind a feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cookies = ["cookie", "cookie_store"]
 socks-proxy = ["socks"]
 gzip = ["flate2"]
 brotli = ["brotli-decompressor"]
+digest-auth = ["digest_auth"]
 
 [dependencies]
 base64 = "0.13"
@@ -44,6 +45,7 @@ rustls-native-certs = { version = "0.6", optional = true }
 native-tls = { version = "0.2", optional = true }
 flate2 = { version = "1.0.22", optional = true }
 brotli-decompressor = { version = "2.3.2", optional = true }
+digest_auth = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -400,6 +400,9 @@ pub use crate::resolve::Resolver;
 pub use crate::response::Response;
 pub use crate::stream::TlsConnector;
 
+#[cfg(feature = "digest-auth")]
+pub use middleware::digest::DigestAuthMiddleware;
+
 // re-export
 #[cfg(feature = "cookies")]
 pub use cookie::Cookie;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -174,11 +174,13 @@ pub mod digest {
 
     /// Provides simple digest authentication powered by the `digest_auth` crate.
     ///
-    /// Any 401 response handled by this middleware is retried once with the
-    /// credentials provided on construction. If authentication fails or the middleware
-    /// is unable to generate an answer to the server challenge (such as a different authentication
-    /// scheme or a malformed challenge) the response is silently passed on to the rest
-    /// of the middleware chain.
+    /// Requests that receive a HTTP 401 response are retried once by this middleware with the
+    /// credentials provided on construction. The retry only happens under these conditions:
+    /// - there is no prior "authorization" header on the request set by the caller or other
+    ///   middleware, and
+    /// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
+    ///
+    /// In other cases, this middle ware acts as a no-op forwarder of requests and responses.
     ///
     /// ```
     /// let arbitrary_username = "MyUsername";

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -177,10 +177,10 @@ pub mod digest {
     /// Requests that receive a HTTP 401 response are retried once by this middleware with the
     /// credentials provided on construction. The retry only happens under these conditions:
     /// - there is no prior "authorization" header on the request set by the caller or other
-    ///   middleware, and
+    ///   middleware, and;
     /// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
     ///
-    /// In other cases, this middle ware acts as a no-op forwarder of requests and responses.
+    /// In other cases, this middleware acts as a no-op forwarder of requests and responses.
     ///
     /// ```
     /// let arbitrary_username = "MyUsername";
@@ -226,7 +226,7 @@ pub mod digest {
     impl Middleware for DigestAuthMiddleware {
         fn handle(&self, request: Request, next: MiddlewareNext) -> Result<Response, Error> {
             // Prevent infinite recursion when doing a nested request below.
-            if request.header("Authorization").is_some() {
+            if request.header("authorization").is_some() {
                 return next.handle(request);
             }
 
@@ -235,7 +235,7 @@ pub mod digest {
                 response.status(),
                 self.construct_answer_to_challenge(&request, &response),
             ) {
-                request.set("Authorization", &challenge_answer).call()
+                request.set("authorization", &challenge_answer).call()
             } else {
                 Ok(response)
             }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -201,12 +201,11 @@ pub mod digest {
                 self.password.as_ref(),
                 Cow::from(path),
             );
-            let answer = challenge
+            challenge
                 .respond(&context)
                 .as_ref()
                 .map(ToString::to_string)
-                .ok()?;
-            Some(answer)
+                .ok()
         }
     }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -177,7 +177,19 @@ pub mod digest {
     /// Any 401 response handled by this middleware is retried once with the
     /// credentials provided on construction. If authentication fails or the middleware
     /// is unable to generate an answer to the server challenge (such as a different authentication
-    /// scheme or a malformed challenge) the response is silently passed on.
+    /// scheme or a malformed challenge) the response is silently passed on to the rest
+    /// of the middleware chain.
+    ///
+    /// ```
+    /// let arbitrary_username = "MyUsername";
+    /// let arbitrary_password = "MyPassword";
+    /// let digest_auth_middleware =
+    ///     ureq::DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
+    /// # let url = String::new();
+    ///
+    /// let agent = ureq::AgentBuilder::new().middleware(digest_auth_middleware).build();
+    /// agent.get(&url).call();
+    /// ```
     pub struct DigestAuthMiddleware {
         username: Cow<'static, str>,
         password: Cow<'static, str>,

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -34,8 +34,5 @@ fn invalid_credentials() {
         .middleware(digest_auth_middleware)
         .build();
     let result = agent.get(&test_url).call();
-    match result {
-        Err(Error::Status(401, _)) => (),
-        _ => panic!("Expected 401 error, received {:?}", result),
-    }
+    assert!(matches!(result, Err(Error::Status(401, _))), "Expected 401 error, received {:?}", result);
 }

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -8,8 +8,10 @@ fn valid_credentials() {
     let arbitrary_password = "MyPassword";
     let digest_auth_middleware =
         DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
-    let test_url =
-        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let test_url = format!(
+        "http://httpbin.org/digest-auth/auth/{}/{}",
+        arbitrary_username, arbitrary_password
+    );
     let agent = AgentBuilder::new()
         .timeout_read(Duration::from_secs(5))
         .timeout_write(Duration::from_secs(5))
@@ -26,13 +28,19 @@ fn invalid_credentials() {
     let bad_password = "BadPassword";
     let digest_auth_middleware =
         DigestAuthMiddleware::new(arbitrary_username.into(), bad_password.into());
-    let test_url =
-        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let test_url = format!(
+        "http://httpbin.org/digest-auth/auth/{}/{}",
+        arbitrary_username, arbitrary_password
+    );
     let agent = AgentBuilder::new()
         .timeout_read(Duration::from_secs(5))
         .timeout_write(Duration::from_secs(5))
         .middleware(digest_auth_middleware)
         .build();
     let result = agent.get(&test_url).call();
-    assert!(matches!(result, Err(Error::Status(401, _))), "Expected 401 error, received {:?}", result);
+    assert!(
+        matches!(result, Err(Error::Status(401, _))),
+        "Expected 401 error, received {:?}",
+        result
+    );
 }

--- a/src/test/digest.rs
+++ b/src/test/digest.rs
@@ -1,0 +1,41 @@
+use std::time::Duration;
+
+use super::super::*;
+
+#[test]
+fn valid_credentials() {
+    let arbitrary_username = "MyUsername";
+    let arbitrary_password = "MyPassword";
+    let digest_auth_middleware =
+        DigestAuthMiddleware::new(arbitrary_username.into(), arbitrary_password.into());
+    let test_url =
+        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let agent = AgentBuilder::new()
+        .timeout_read(Duration::from_secs(5))
+        .timeout_write(Duration::from_secs(5))
+        .middleware(digest_auth_middleware)
+        .build();
+    let result = agent.get(&test_url).call();
+    assert_eq!(result.unwrap().status(), 200);
+}
+
+#[test]
+fn invalid_credentials() {
+    let arbitrary_username = "MyUsername";
+    let arbitrary_password = "MyPassword";
+    let bad_password = "BadPassword";
+    let digest_auth_middleware =
+        DigestAuthMiddleware::new(arbitrary_username.into(), bad_password.into());
+    let test_url =
+        format!("http://httpbin.org/digest-auth/auth/{arbitrary_username}/{arbitrary_password}");
+    let agent = AgentBuilder::new()
+        .timeout_read(Duration::from_secs(5))
+        .timeout_write(Duration::from_secs(5))
+        .middleware(digest_auth_middleware)
+        .build();
+    let result = agent.get(&test_url).call();
+    match result {
+        Err(Error::Status(401, _)) => (),
+        _ => panic!("Expected 401 error, received {:?}", result),
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -9,6 +9,8 @@ use std::sync::{Arc, Mutex};
 mod agent_test;
 mod body_read;
 mod body_send;
+#[cfg(feature = "digest-auth")]
+mod digest;
 mod query_string;
 mod range;
 mod redirect;


### PR DESCRIPTION
For pre-review before sharing with upstream `ureq`.

Some thoughts:
* The crate organization is pretty nice and flat, so it felt wrong to add a sub-folder for specific middlewares. I added this instead as an inline module under the `middleware` one.
* I don't love contacting external services for unit tests, but I see they've done similar things in the `tls` tests so I'm doing this now for simplicity, until the `ureq` maintainers advise a better way to unit test it.