### PR TITLE
Digest middleware feature (ureq v3)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           - brotli
           - json
           - native-tls
+          - digest-auth
     env:
       RUST_BACKTRACE: "1"
       RUSTFLAGS: "-D dead_code -D unused-variables -D unused"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "brotli-decompressor"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,12 +327,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -343,6 +371,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest",
+ "hex",
+ "md-5",
+ "rand",
+ "sha2",
 ]
 
 [[package]]
@@ -478,6 +529,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +560,12 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -804,6 +871,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1037,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,6 +1089,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2 1.0.94",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1242,6 +1358,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,6 +1512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,6 +1545,7 @@ dependencies = [
  "brotli-decompressor",
  "cookie_store",
  "der",
+ "digest_auth",
  "encoding_rs",
  "env_logger",
  "flate2",
@@ -1750,6 +1884,26 @@ dependencies = [
  "quote 1.0.40",
  "syn 2.0.100",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2 1.0.94",
+ "quote 1.0.40",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
 charset = ["dep:encoding_rs"]
 json = ["dep:serde", "dep:serde_json", "cookie_store?/serde_json"]
-digest-auth = ["digest_auth"]
+digest-auth = ["dep:digest_auth"]
 
 ######## UNSTABLE FEATURES.
 # Might be removed or changed in a minor version.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = ["/cargo_deny.sh", "/deny.toml", "/test.sh"]
 rust-version = "1.71.1"
 
 [package.metadata.docs.rs]
-features = ["rustls", "platform-verifier", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "_test", "_doc"]
+features = ["rustls", "platform-verifier", "native-tls", "socks-proxy", "cookies", "gzip", "brotli", "charset", "json", "digest-auth", "_test", "_doc"]
 
 [features]
 default = ["rustls", "gzip"]
@@ -31,6 +31,7 @@ gzip = ["dep:flate2"]
 brotli = ["dep:brotli-decompressor"]
 charset = ["dep:encoding_rs"]
 json = ["dep:serde", "dep:serde_json", "cookie_store?/serde_json"]
+digest-auth = ["digest_auth"]
 
 ######## UNSTABLE FEATURES.
 # Might be removed or changed in a minor version.
@@ -88,6 +89,8 @@ encoding_rs = { version = "0.8.34", optional = true }
 
 serde = { version = "1.0.138", optional = true, default-features = false, features = ["std"] }
 serde_json = { version = "1.0.120", optional = true, default-features = false, features = ["std"] }
+
+digest_auth = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1085,8 +1085,8 @@ pub(crate) mod test {
         let arbitrary_username = "MyUsername";
         let arbitrary_password = "MyPassword";
         let digest_auth_middleware = crate::middleware::digest::DigestAuthMiddleware::new(
-            arbitrary_username,
-            arbitrary_password,
+            arbitrary_username.to_string(),
+            arbitrary_password.to_string(),
         );
         let test_url = format!(
             "http://httpbin.org/digest-auth/auth/{}/{}",
@@ -1108,8 +1108,10 @@ pub(crate) mod test {
         let arbitrary_username = "MyUsername";
         let arbitrary_password = "MyPassword";
         let bad_password = "BadPassword";
-        let digest_auth_middleware =
-            crate::middleware::digest::DigestAuthMiddleware::new(arbitrary_username, bad_password);
+        let digest_auth_middleware = crate::middleware::digest::DigestAuthMiddleware::new(
+            arbitrary_username.to_string(),
+            bad_password.to_string(),
+        );
         let test_url = format!(
             "http://httpbin.org/digest-auth/auth/{}/{}",
             arbitrary_username, arbitrary_password

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,6 +549,9 @@ use unversioned::transport;
 
 pub mod middleware;
 
+#[cfg(feature = "digest-auth")]
+pub use middleware::digest::DigestAuthMiddleware;
+
 #[cfg(feature = "_tls")]
 pub mod tls;
 
@@ -698,6 +701,9 @@ where
 #[cfg(test)]
 pub(crate) mod test {
     use std::{io, sync::OnceLock};
+
+    #[cfg(feature = "digest-auth")]
+    use std::time::Duration;
 
     use assert_no_alloc::AllocDisabler;
     use config::{Config, ConfigBuilder};
@@ -1071,6 +1077,51 @@ pub(crate) mod test {
         jar.release();
 
         let _ = agent.get("http://cookie.test/cookie-test").call().unwrap();
+    }
+
+    #[test]
+    #[cfg(feature = "digest-auth")]
+    fn valid_credentials() {
+        let arbitrary_username = "MyUsername";
+        let arbitrary_password = "MyPassword";
+        let digest_auth_middleware = crate::middleware::digest::DigestAuthMiddleware::new(
+            arbitrary_username,
+            arbitrary_password,
+        );
+        let test_url = format!(
+            "http://httpbin.org/digest-auth/auth/{}/{}",
+            arbitrary_username, arbitrary_password
+        );
+        let agent: Agent = crate::config::Config::builder()
+            .timeout_global(Some(Duration::from_secs(5)))
+            .http_status_as_error(false)
+            .middleware(digest_auth_middleware)
+            .build()
+            .into();
+        let result = agent.get(&test_url).call();
+        assert_eq!(result.unwrap().status(), 200);
+    }
+
+    #[test]
+    #[cfg(feature = "digest-auth")]
+    fn invalid_credentials() {
+        let arbitrary_username = "MyUsername";
+        let arbitrary_password = "MyPassword";
+        let bad_password = "BadPassword";
+        let digest_auth_middleware =
+            crate::middleware::digest::DigestAuthMiddleware::new(arbitrary_username, bad_password);
+        let test_url = format!(
+            "http://httpbin.org/digest-auth/auth/{}/{}",
+            arbitrary_username, arbitrary_password
+        );
+        let agent: Agent = crate::config::Config::builder()
+            .timeout_global(Some(Duration::from_secs(5)))
+            .http_status_as_error(false)
+            .middleware(digest_auth_middleware)
+            .build()
+            .into();
+        let result = agent.get(&test_url).call();
+        assert_eq!(result.unwrap().status(), 401);
     }
 
     #[test]

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -83,6 +83,8 @@ impl Middleware for DigestAuthMiddleware {
         let request = http::Request::from_parts(parts.clone(), body);
         let agent = next.agent;
 
+        // TODO (jacksongoode): Should be able to catch 401 without http_status_as_error(false)
+        // but headers are lost in the returned error.
         let response = next.handle(request)?;
 
         if response.status() == http::StatusCode::UNAUTHORIZED {
@@ -93,6 +95,7 @@ impl Middleware for DigestAuthMiddleware {
                     .headers
                     .insert(http::header::AUTHORIZATION, challenge_answer_header);
 
+                // TODO (jacksongoode): Should preserve and send original body.
                 let retry_request = http::Request::from_parts(parts, SendBody::none());
                 return agent.run(retry_request);
             }

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -22,8 +22,8 @@ use std::str::FromStr;
 /// ```
 /// let arbitrary_username = "MyUsername";
 /// let arbitrary_password = "MyPassword";
-/// let digest_auth_middleware =
-///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
+/// let digest_auth_middleware = ureq::DigestAuthMiddleware::new(
+///     arbitrary_username.to_string(), arbitrary_password.to_string());
 /// # let url = String::new();
 ///
 /// let agent: ureq::Agent = ureq::config::Config::builder()
@@ -40,10 +40,10 @@ pub struct DigestAuthMiddleware {
 
 impl DigestAuthMiddleware {
     /// Create a new digest authentication middleware.
-    pub fn new(username: &str, password: &str) -> Self {
+    pub fn new(username: String, password: String) -> Self {
         Self {
-            username: username.into(),
-            password: password.into(),
+            username: username,
+            password: password,
         }
     }
 

--- a/src/middleware/digest.rs
+++ b/src/middleware/digest.rs
@@ -1,0 +1,105 @@
+use crate::middleware::{Middleware, MiddlewareNext};
+use crate::{http, Body, Error, SendBody};
+use digest_auth::{AuthContext, WwwAuthenticateHeader};
+use std::str::FromStr;
+
+/// Provides simple digest authentication powered by the `digest_auth` crate.
+///
+/// Requests that receive a HTTP 401 response are retried once by this middleware with the
+/// credentials provided on construction. The retry only happens under these conditions:
+/// - there is no prior "authorization" header on the request set by the caller or other
+///   middleware, and;
+/// - the server provides HTTP Digest auth challenge in the "www-authenticate" header.
+/// - the request body is empty (limitation to avoid body consumption issues)
+///
+/// In other cases, this middleware acts as a no-op forwarder of requests and responses.
+///
+/// **Note**: This middleware requires [`http_status_as_error(false)`] to be configured
+/// on the agent, as it needs to respond to 401's rather than treat them as errors.
+///
+/// [`http_status_as_error(false)`]: crate::config::ConfigBuilder::http_status_as_error
+///
+/// ```
+/// let arbitrary_username = "MyUsername";
+/// let arbitrary_password = "MyPassword";
+/// let digest_auth_middleware =
+///     ureq::DigestAuthMiddleware::new(arbitrary_username, arbitrary_password);
+/// # let url = String::new();
+///
+/// let agent = ureq::config::Config::builder()
+///     .http_status_as_error(false)  // Required for digest auth
+///     .middleware(digest_auth_middleware)
+///     .build()
+///     .into();
+/// agent.get(&url).call();
+/// ```
+pub struct DigestAuthMiddleware {
+    username: String,
+    password: String,
+}
+
+impl DigestAuthMiddleware {
+    /// Create a new digest authentication middleware.
+    pub fn new(username: &str, password: &str) -> Self {
+        Self {
+            username: username.into(),
+            password: password.into(),
+        }
+    }
+
+    fn respond_to_challenge(
+        &self,
+        uri: &http::Uri,
+        response: &http::Response<Body>,
+    ) -> Option<String> {
+        let challenge_string = response.headers().get("www-authenticate")?.to_str().ok()?;
+        let mut challenge = WwwAuthenticateHeader::from_str(challenge_string).ok()?;
+        let path = uri.path();
+        let context = AuthContext::new(&self.username, &self.password, path);
+        challenge
+            .respond(&context)
+            .as_ref()
+            .map(ToString::to_string)
+            .ok()
+    }
+}
+
+impl Middleware for DigestAuthMiddleware {
+    fn handle(
+        &self,
+        request: http::Request<SendBody>,
+        next: MiddlewareNext,
+    ) -> Result<http::Response<Body>, Error> {
+        // Prevent infinite recursion when doing a nested request below.
+        if request.headers().get("authorization").is_some() {
+            return next.handle(request);
+        }
+
+        // Clone for the authentication challenge response.
+        let (parts, body) = request.into_parts();
+        let request = http::Request::from_parts(parts.clone(), body);
+        let agent = next.agent;
+
+        let response = next.handle(request)?;
+
+        if response.status() == 401 {
+            if let Some(challenge_answer) = self.respond_to_challenge(&parts.uri, &response) {
+                let mut retry_parts = parts;
+                retry_parts.headers.insert(
+                    "authorization",
+                    challenge_answer.parse().map_err(|_| {
+                        Error::Io(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "Invalid authorization header",
+                        ))
+                    })?,
+                );
+
+                let retry_request = http::Request::from_parts(retry_parts, SendBody::none());
+                return agent.run(retry_request);
+            }
+        }
+
+        Ok(response)
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -7,6 +7,10 @@ use crate::http;
 use crate::run::run;
 use crate::{Agent, Body, Error, SendBody};
 
+#[cfg(feature = "digest-auth")]
+/// Digest authentication middleware.
+pub mod digest;
+
 /// Chained processing of request (and response).
 ///
 /// # Middleware as `fn`


### PR DESCRIPTION
We could merge into `main` I suppose but this was created to compliment https://github.com/tonarino/portal/pull/4876.

As a point of comparison, this should look similar to https://github.com/algesten/ureq/compare/main...tonarino:ureq:feature/implement-digest-authentication-middleware but with some method changes and behavior to work with ureq v3.